### PR TITLE
Add ip route for allowed ips

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -146,6 +146,9 @@ runs:
             fi
 
             sudo ip link set "$ifname" up
+            
+            # Add routes for allowed_ips
+            for i in ${allowed_ips//,/ }; do sudo ip route replace "$i" dev "$ifname"; done
         }
 
         # systemd-networkd greets me with 'Temporary failure in name


### PR DESCRIPTION
wg command do not add ip route for allowed-ips like wg-quick. add command to ad ip route for all networks in allowed-ips.